### PR TITLE
feat: Test Code

### DIFF
--- a/be-dev/build.gradle
+++ b/be-dev/build.gradle
@@ -31,7 +31,10 @@ dependencies {
     implementation 'mysql:mysql-connector-java:8.0.33'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'   // Spring Boot 기본 테스트
+    testImplementation 'org.mockito:mockito-core'     // Mockito 기본
+    testImplementation 'org.mockito:mockito-junit-jupiter' // JUnit 5용 Mockito
+    testImplementation 'org.springframework.security:spring-security-test' // Spring Security 테스트 지원
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/be-dev/src/test/java/com/example/demo/controller/StockControllerTest.java
+++ b/be-dev/src/test/java/com/example/demo/controller/StockControllerTest.java
@@ -1,0 +1,63 @@
+package com.example.demo.controller;
+
+import com.example.demo.service.StockService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc  // MockMvc 자동 설정
+class StockControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StockService stockService;  // 실제 빈 대신 Mock 객체 사용
+
+    private static final String API_KEY = "c18aa07f-f005-4c2f-b6db-dff8294e6b5e";
+
+    @Test
+    @DisplayName("정상 요청 - 200 OK")
+    void getStockPrices_Success() throws Exception {
+        mockMvc.perform(get("/api/v1/stock/AAPL")
+                .param("startDate", "2024-01-01")
+                .param("endDate", "2024-01-10")
+                .header("x-api-key", API_KEY))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("필수 파라미터 누락 - 400 Bad Request")
+    void getStockPrices_MissingParams() throws Exception {
+        mockMvc.perform(get("/api/v1/stock/AAPL")
+                .header("x-api-key", API_KEY))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("API 키 누락 - 400 Bad Request")
+    void getStockPrices_MissingApiKey() throws Exception {
+        mockMvc.perform(get("/api/v1/stock/AAPL")
+                .param("startDate", "2024-01-01")
+                .param("endDate", "2024-01-10"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("잘못된 API 키 - 403 Forbidden")
+    void getStockPrices_InvalidApiKey() throws Exception {
+        mockMvc.perform(get("/api/v1/stock/AAPL")
+                .param("startDate", "2024-01-01")
+                .param("endDate", "2024-01-10")
+                .header("x-api-key", "invalid-key"))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
#  주가 조회 API 테스트 코드 추가  

## 변경 사항  
- `StockControllerTest` 추가하여 API 테스트 작성  
  - 정상 요청 (`200 OK`)  
  - 필수 파라미터 누락 시 (`400 Bad Request`)  
  - API 키 누락 시 (`400 Bad Request`)  
  - 잘못된 API 키 사용 시 (`403 Forbidden`)  

## 체크리스트  
- [x] 정상적인 API 요청이 통과되는가?  
- [x] 필수 파라미터 누락 시 적절한 에러 코드(400)를 반환하는가?  
- [x] API 키가 없거나 잘못되었을 때 적절한 에러 코드(400, 403)를 반환하는가?  

##  테스트 결과  
- `./gradlew clean test` 실행하여 모든 테스트 통과 확인 