### PR TITLE
feat: support XML response for stock data

### DIFF
--- a/be-dev/build.gradle
+++ b/be-dev/build.gradle
@@ -29,12 +29,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'mysql:mysql-connector-java:8.0.33'
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
+    implementation 'org.glassfish.jaxb:jaxb-runtime:4.0.4'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'   // Spring Boot 기본 테스트
     testImplementation 'org.mockito:mockito-core'     // Mockito 기본
     testImplementation 'org.mockito:mockito-junit-jupiter' // JUnit 5용 Mockito
     testImplementation 'org.springframework.security:spring-security-test' // Spring Security 테스트 지원
+    testImplementation 'org.springframework.boot:spring-boot-starter-webflux' // `MockMvc` 테스트 지원
+
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/be-dev/src/main/java/com/example/demo/controller/StockController.java
+++ b/be-dev/src/main/java/com/example/demo/controller/StockController.java
@@ -2,6 +2,10 @@ package com.example.demo.controller;
 
 import com.example.demo.dto.StockResponseDTO;
 import com.example.demo.service.StockService;
+import com.example.demo.dto.StockListResponseDTO;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,17 +35,21 @@ public class StockController {
      * 특정 기업의 주식 가격 조회 API
      * - 회사 코드, 조회 시작 날짜, 종료 날짜를 기준으로 데이터를 조회
      * - API Key 인증 필요
+     * - `format` 요청 파라미터 또는 `Accept` 헤더를 기반으로 JSON/XML 응답 제공
      *
      * @param companyCode 조회할 기업 코드 (예: "AAPL")
      * @param startDate 조회 시작 날짜 (yyyy-MM-dd)
      * @param endDate 조회 종료 날짜 (yyyy-MM-dd)
+     * @param format 응답 포맷 (json 또는 xml) [선택 사항]
      * @return 주식 종가 데이터 리스트 또는 400 Bad Request
      */
-    @GetMapping("/{companyCode}")
-    public ResponseEntity<List<StockResponseDTO>> getStockPrices(
+    @GetMapping(value = "/{companyCode}", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+    public ResponseEntity<?> getStockPrices(
         @PathVariable String companyCode,
         @RequestParam String startDate,
-        @RequestParam String endDate
+        @RequestParam String endDate,
+        @RequestParam(required = false) String format,
+        @RequestHeader(value = HttpHeaders.ACCEPT, required = false) String acceptHeader
     ) {
         // 날짜 형식 검증
         LocalDate start, end;
@@ -52,8 +60,20 @@ public class StockController {
             return ResponseEntity.badRequest().build(); // 400 Bad Request 반환
         }
 
-        // 주식 데이터 조회 및 응답 반환
+        // 주식 데이터 조회
         List<StockResponseDTO> response = stockService.getStockPrices(companyCode, start, end);
-        return ResponseEntity.ok(response);
+
+        // 응답 포맷 결정 (format 파라미터 > Accept 헤더)
+        String responseFormat = (format != null) ? format : ((acceptHeader != null) ? acceptHeader : "json");
+
+        if ("xml".equals(responseFormat) || MediaType.APPLICATION_XML_VALUE.equals(responseFormat)) {
+            return ResponseEntity.ok()
+                    .contentType(MediaType.APPLICATION_XML)
+                    .body(new StockListResponseDTO(response));
+        }
+
+        return ResponseEntity.ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(response);
     }
 }

--- a/be-dev/src/main/java/com/example/demo/dto/StockListResponseDTO.java
+++ b/be-dev/src/main/java/com/example/demo/dto/StockListResponseDTO.java
@@ -1,0 +1,18 @@
+package com.example.demo.dto;
+
+import com.example.demo.dto.StockResponseDTO;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+@XmlRootElement(name = "stocks")
+public class StockListResponseDTO {
+    @XmlElement(name = "stock")
+    private List<StockResponseDTO> stocks;
+
+    public StockListResponseDTO() {} // 기본 생성자 필요
+
+    public StockListResponseDTO(List<StockResponseDTO> stocks) {
+        this.stocks = stocks;
+    }
+}

--- a/be-dev/src/main/java/com/example/demo/dto/StockResponseDTO.java
+++ b/be-dev/src/main/java/com/example/demo/dto/StockResponseDTO.java
@@ -2,6 +2,13 @@ package com.example.demo.dto;
 
 import lombok.Getter;
 import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlElement;
+
+
 
 /**
  * 주식 조회 응답 DTO
@@ -9,9 +16,17 @@ import lombok.AllArgsConstructor;
  * - 특정 기업의 종가(closingPrice) 및 거래 날짜(tradeDate)를 포함
  */
 @Getter
+@NoArgsConstructor // XML 변환을 위해 기본 생성자 필요
 @AllArgsConstructor
+@XmlRootElement(name = "stock") // XML 직렬화
+@XmlAccessorType(XmlAccessType.FIELD)
 public class StockResponseDTO {
-    private String companyName;  // 응답 시 회사명 포함
-    private String tradeDate;    // yyyy-MM-dd 형식 유지
+    @XmlElement(name = "companyName")  // XML에서 이 필드 포함
+    private String companyName;   // 응답 시 회사명 포함
+    
+    @XmlElement(name = "tradeDate")
+    private String tradeDate;   // yyyy-MM-dd 형식 유지
+    
+    @XmlElement(name = "closingPrice")
     private long closingPrice;   // 종가 (tradePrice)
 }

--- a/be-dev/src/test/java/com/example/demo/controller/StockControllerTest.java
+++ b/be-dev/src/test/java/com/example/demo/controller/StockControllerTest.java
@@ -8,9 +8,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
 @SpringBootTest
 @AutoConfigureMockMvc  // MockMvc 자동 설정
@@ -32,6 +34,31 @@ class StockControllerTest {
                 .param("endDate", "2024-01-10")
                 .header("x-api-key", API_KEY))
                 .andExpect(status().isOk());
+    }
+
+
+    @Test
+    @DisplayName("정상 요청 - JSON 응답")
+    void getStockPrices_JSON_Success() throws Exception {
+        mockMvc.perform(get("/api/v1/stock/AAPL")
+                .param("startDate", "2024-01-01")
+                .param("endDate", "2024-01-10")
+                .header("x-api-key", API_KEY)
+                .accept(MediaType.APPLICATION_JSON))  // JSON 응답 요청
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON)); // JSON 타입 확인
+    }
+
+    @Test
+    @DisplayName("정상 요청 - XML 응답")
+    void getStockPrices_XML_Success() throws Exception {
+        mockMvc.perform(get("/api/v1/stock/AAPL")
+                .param("startDate", "2024-01-01")
+                .param("endDate", "2024-01-10")
+                .header("x-api-key", API_KEY)
+                .accept(MediaType.APPLICATION_XML))  // XML 응답 요청
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML)); // XML 타입 확인
     }
 
     @Test


### PR DESCRIPTION
# [Feature] XML 응답 지원 추가 및 JSON 응답 개선  

## 변경 사항  
기존 JSON 응답 방식에 추가로 **XML 응답**을 지원하도록 기능을 확장하였습니다.  
API 요청 시 `Accept` 헤더 또는 `format` 파라미터를 통해 원하는 응답 타입(JSON/XML)을 선택할 수 있도록 구현하였습니다.  

---

## 주요 변경 내용  

### **StockResponseDTO.java에 XML 직렬화 지원 추가**
- `@XmlRootElement`, `@XmlAccessorType`, `@XmlElement` 어노테이션 추가  
- XML 응답 시 필드 이름을 명확히 지정  

```java
@Getter
@NoArgsConstructor
@AllArgsConstructor
@XmlRootElement(name = "stock")
@XmlAccessorType(XmlAccessType.FIELD)
public class StockResponseDTO {
    @XmlElement(name = "companyName")
    private String companyName;
    
    @XmlElement(name = "tradeDate")
    private String tradeDate;
    
    @XmlElement(name = "closingPrice")
    private long closingPrice;
}
```

---

### **StockListResponseDTO.java 추가 (XML 응답의 루트 태그 역할)**
- XML 응답의 루트 요소를 `<stocks>`로 설정  
- 주식 데이터 리스트를 포함하도록 설계  

```java
@XmlRootElement(name = "stocks")
public class StockListResponseDTO {
    @XmlElement(name = "stock")
    private List<StockResponseDTO> stocks;
    
    public StockListResponseDTO() {} 
    
    public StockListResponseDTO(List<StockResponseDTO> stocks) {
        this.stocks = stocks;
    }
}
```

---

### **StockController.java 수정 (JSON & XML 응답 지원)**
- `@GetMapping`의 `produces` 속성을 활용하여 JSON/XML 응답을 지원  
- `Accept` 헤더 또는 `format` 파라미터를 기반으로 응답 타입 결정  

```java
@GetMapping(value = "/{companyCode}", produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
public ResponseEntity<?> getStockPrices(
    @PathVariable String companyCode,
    @RequestParam String startDate,
    @RequestParam String endDate,
    @RequestParam(required = false) String format,
    @RequestHeader(value = HttpHeaders.ACCEPT, required = false) String acceptHeader
) {
    List<StockResponseDTO> response = stockService.getStockPrices(companyCode, LocalDate.parse(startDate), LocalDate.parse(endDate));
    
    // 응답 타입 결정 (format 파라미터 > Accept 헤더)
    String responseFormat = (format != null) ? format : ((acceptHeader != null) ? acceptHeader : "json");

    if (responseFormat.contains("xml")) {
        return ResponseEntity.ok().contentType(MediaType.APPLICATION_XML).body(new StockListResponseDTO(response));
    }

    return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(response);
}
```

---

### **테스트 코드 추가 (`StockControllerTest.java`)**
- `MockMvc`를 활용한 JSON 및 XML 응답 테스트 추가  
- `Accept` 헤더를 변경하여 응답 타입이 정상적으로 반환되는지 검증  

```java
@Test
@DisplayName("정상 요청 - JSON 응답")
void getStockPrices_JSON_Success() throws Exception {
    mockMvc.perform(get("/api/v1/stock/AAPL")
            .param("startDate", "2024-01-01")
            .param("endDate", "2024-01-10")
            .header("x-api-key", API_KEY)
            .accept(MediaType.APPLICATION_JSON))
            .andExpect(status().isOk())
            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
}

@Test
@DisplayName("정상 요청 - XML 응답")
void getStockPrices_XML_Success() throws Exception {
    mockMvc.perform(get("/api/v1/stock/AAPL")
            .param("startDate", "2024-01-01")
            .param("endDate", "2024-01-10")
            .header("x-api-key", API_KEY)
            .accept(MediaType.APPLICATION_XML))
            .andExpect(status().isOk())
            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
}
```

---

## **Gradle Dependencies 추가**
- XML 직렬화를 위한 JAXB 관련 의존성 추가  

```gradle
dependencies {
    implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
    implementation 'org.glassfish.jaxb:jaxb-runtime:4.0.4'
}
```

---

## 테스트 및 검증 방법  
### JSON 응답 테스트  
```sh
curl -X GET "http://localhost:8080/api/v1/stock/AAPL?startDate=2024-01-01&endDate=2024-01-10" \
     -H "x-api-key: {API_KEY}" \
     -H "Accept: application/json" | jq
```

### XML 응답 테스트  
```sh
curl -X GET "http://localhost:8080/api/v1/stock/AAPL?startDate=2024-01-01&endDate=2024-01-10" \
     -H "x-api-key: {API_KEY}" \
     -H "Accept: application/xml" | xmllint --format -
```